### PR TITLE
Replace rental with self_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
  "itertools",
  "lang_fall_syntax",
  "regex",
- "rental",
+ "self_cell",
  "serde",
 ]
 
@@ -865,12 +865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procedural-masquerade"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1bcafee1590f81acb329ae45ec627b318123f085153913620316ae9a144b2a"
-
-[[package]]
 name = "proptest"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,12 +882,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -1041,27 +1029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rental"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f098d5bfcbc5b929baf992ca6e09244daf4b47d1aedba3a808364faf48bd036e"
-dependencies = [
- "rental-impl",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "rental-impl"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb24fb6b34fdd7b264154ea85c34bf9d3a9ac1355163b6e22ab8262f9f4a73f1"
-dependencies = [
- "procedural-masquerade",
- "quote 0.3.15",
- "syn 0.11.11",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1048,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c924e8e521faa453317ab6887122657f1855e9c46f0fb5e6b4bdc3be845353"
 
 [[package]]
 name = "serde"
@@ -1149,27 +1122,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
 
 [[package]]
 name = "syn"
@@ -1191,15 +1147,6 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -1363,12 +1310,6 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"

--- a/lang/fall/Cargo.toml
+++ b/lang/fall/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2018"
 
 [dependencies]
 itertools = "0.7.4"
-rental = "0.4"
-serde = "1.*"
 regex = "1"
+self_cell = "0.8"
+serde = "1.*"
 
 fall_tree = { path = "../../fall/tree" }
 fall_parse = { path = "../../fall/parse" }

--- a/lang/fall/src/editor/mod.rs
+++ b/lang/fall/src/editor/mod.rs
@@ -19,12 +19,12 @@ pub use crate::analysis::FileWithAnalysis;
 
 impl EditorFileImpl for FileWithAnalysis {
     fn parse(text: &str) -> Self {
-        FileWithAnalysis::new(lang_fall().parse(text))
+        FileWithAnalysis::try_from(lang_fall().parse(text)).unwrap()
     }
 
     fn edit(&self, edit: &TextEdit) -> Self {
         let file = self.file().edit(edit);
-        FileWithAnalysis::new(file)
+        FileWithAnalysis::try_from(file).unwrap()
     }
 
     fn file(&self) -> &File {

--- a/lang/fall/src/lib.rs
+++ b/lang/fall/src/lib.rs
@@ -1,8 +1,6 @@
 extern crate itertools;
 extern crate regex;
 extern crate serde;
-#[macro_use]
-extern crate rental;
 
 extern crate fall_tree;
 extern crate fall_parse;
@@ -22,7 +20,7 @@ pub fn parse<S: Into<String>>(text: S) -> File {
 }
 
 pub fn analyse<S: Into<String>>(text: S) -> FileWithAnalysis {
-    FileWithAnalysis::new(parse(text))
+    FileWithAnalysis::try_from(parse(text)).unwrap()
 }
 
 pub fn ast(file: &File) -> syntax::FallFile {


### PR DESCRIPTION
Before:

$ cargo build
... 67 dependencies
Finished dev [unoptimized + debuginfo] target(s) in 51.82s

After:

$ cargo build
... 60 dependencies
Finished dev [unoptimized + debuginfo] target(s) in 37.29s

That's 39% faster in this very rough test. But the 7 fewer dependencies make this seem plausible. There are still some proc macro dependencies like syn left, but they have nothing to do with `self_cell` as it has 0 dependencies and doesn't use proc macros.

Disclaimer I'm the author of `self_cell`.

I ran `cargo test` and all non skipped tests passed before and after.

Note, rental is no longer maintained and ouroboros still carries the compile time cost of proc macros. Plus https://github.com/scpwiki/wikijump/pull/270#pullrequestreview-655216432 here they noticed a perf boost over ouroboros.